### PR TITLE
Preallocate arrays in simulation run functions

### DIFF
--- a/runMCPotts.m
+++ b/runMCPotts.m
@@ -22,6 +22,15 @@ set(groot, 'DefaultAxesLineWidth', 2);
 acc = 0;
 R = 8.3144598;
 
+% Preallocate arrays using the final number of Monte Carlo sweeps
+final_nstep = MCS + nconfig / N;
+totalEnergyArr(final_nstep) = 0;
+grainBoundaryEnergyArr(final_nstep) = 0;
+strainEnergyArr(final_nstep) = 0;
+pacc(final_nstep) = 0;
+prex(final_nstep) = 0;
+time(final_nstep) = 0;
+
 if MCS == 0
     imagesc(ax1, s);
 

--- a/runMCPottsHeterogeneous.m
+++ b/runMCPottsHeterogeneous.m
@@ -17,6 +17,15 @@ set(groot, 'DefaultAxesLineWidth', 2);
 acc = 0;
 R = 8.3144598;
 
+% Preallocate arrays using the final number of Monte Carlo sweeps
+final_nstep = MCS + nconfig / N;
+totalEnergyArr(final_nstep) = 0;
+grainBoundaryEnergyArr(final_nstep) = 0;
+strainEnergyArr(final_nstep) = 0;
+pacc(final_nstep) = 0;
+prex(final_nstep) = 0;
+time(final_nstep) = 0;
+
 if MCS == 0
     imagesc(ax1, s);
     load('customColormap.mat', 'CustomColormap');


### PR DESCRIPTION
## Summary
- preallocate energy and metric arrays in `runMCPotts` and `runMCPottsHeterogeneous`

## Testing
- `octave -qf --eval "disp('test')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847736bbde48320806009dfdb492595