### PR TITLE
Allow Monte Carlo spin 1 transformations

### DIFF
--- a/runMCPotts.m
+++ b/runMCPotts.m
@@ -54,10 +54,6 @@ for k = 1:nconfig
     sij = sij + ceil((q - 1) * rand);
     sij = sij - q * floor((sij - 1) / q);
 
-    while strain_energy && sij == 1
-        sij = sij + ceil((q - 1) * rand);
-        sij = sij - q * floor((sij - 1) / q);
-    end
 
     sign = calculateEnergy(sij, s, n, i, j);
     sigo = calculateEnergy(sijo, s, n, i, j);

--- a/runMCPottsHeterogeneous.m
+++ b/runMCPottsHeterogeneous.m
@@ -42,11 +42,6 @@ for k = 1:nconfig
     sij = sij + ceil((q - 1) * rand);
     sij = sij - q * floor((sij - 1) / q);
 
-    % Prevent changing to spin = 1 if strain energy is present
-    while strain_energy_map(i, j) > 0 && sij == 1
-        sij = sij + ceil((q - 1) * rand);
-        sij = sij - q * floor((sij - 1) / q);
-    end
 
     sign = calculateEnergy(sij, s, n, i, j);
     sigo = calculateEnergy(sijo, s, n, i, j);


### PR DESCRIPTION
## Summary
- allow deformed cells to change to spin 1
- remove blocking while-loop in both MC Potts scripts

## Testing
- `octave --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68477174e27c8320b4bff779145c90d8